### PR TITLE
Adds the ability to pass fields into loadMany

### DIFF
--- a/src/clients/mongoclient.js
+++ b/src/clients/mongoclient.js
@@ -152,7 +152,8 @@ export class MongoClient extends DatabaseClient {
         query = castQueryIds(query);
         return new Promise(function(resolve, reject) {
             var db = that._mongo.collection(collection);
-            var cursor = db.find(query);
+            var fields = options.fields || {};
+            var cursor = db.find(query, fields);
             if (typeof options.sort === 'string') {
                 var sortOrder = 1;
                 if (options.sort[0] === '-') {


### PR DESCRIPTION
We need the ability to pass `fields` into `loadMany` so we can exclude some data from being returned. Added `fields` as a nested object inside `options` similar to `sort`, `skip`, and `limit`.
